### PR TITLE
Make deployment user permissions more specific

### DIFF
--- a/serverless/DEVELOPER_README.md
+++ b/serverless/DEVELOPER_README.md
@@ -280,7 +280,11 @@ The user **deploying** this project **must** have the following permissions list
 				"apigateway:PUT",
 				"apigateway:TagResource"
 			],
-			"Resource": "*"
+			"Resource": [
+                "arn:aws:apigateway:<region>::/apis/*",
+                "arn:aws:apigateway:<region>::/apis",
+                "arn:aws:apigateway:<region>::/tags/*"
+            ]
 		},
 		{
 			"Sid": "VisualEditor1",

--- a/serverless/DEVELOPER_README.md
+++ b/serverless/DEVELOPER_README.md
@@ -281,10 +281,10 @@ The user **deploying** this project **must** have the following permissions list
 				"apigateway:TagResource"
 			],
 			"Resource": [
-                "arn:aws:apigateway:<region>::/apis/*",
-                "arn:aws:apigateway:<region>::/apis",
-                "arn:aws:apigateway:<region>::/tags/*"
-            ]
+				"arn:aws:apigateway:<region>::/apis/*",
+				"arn:aws:apigateway:<region>::/apis",
+				"arn:aws:apigateway:<region>::/tags/*"
+			]
 		},
 		{
 			"Sid": "VisualEditor1",


### PR DESCRIPTION
The API Gateway permissions documented in `serverless/DEVELOPER_README.md` for the deployment user have been made more specific.

- [x] Tested deployment with new permissions.