### PR TITLE
Bumping `golangci-lint`

### DIFF
--- a/.github/workflows/go-build-test.yml
+++ b/.github/workflows/go-build-test.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           cache: false
         env:
           GO111MODULE: on
@@ -59,5 +59,5 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           skip-cache: true
-          version: v1.60.1
+          version: v1.64.5
           args: --exclude ".Log(.*)|format.Set|level.Set" --timeout=2m


### PR DESCRIPTION
`golangci-lint` added support for Go v1.24 so we can just bump the version. I still think it's a good idea to keep the version fixed though, as it helps avoid unexpected failures due to version upgrades.